### PR TITLE
fix bug in checkpoint

### DIFF
--- a/trainer/checkpoint.py
+++ b/trainer/checkpoint.py
@@ -4,19 +4,21 @@ import os
 from datetime import datetime
 from configs import config_from_dict
 
+
 class Checkpoint():
     """
     Checkpoint for saving model state
     :param save_per_epoch: (int)
     :param path: (string)
     """
-    def __init__(self, save_per_iter = 1000, path = None):
+
+    def __init__(self, save_per_iter=1000, path=None):
         self.path = path
         self.save_per_iter = save_per_iter
         # Create folder
         if self.path is None:
-            self.path = os.path.join('weights',datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))
-        
+            self.path = os.path.join(
+                'weights', datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))
 
     def save(self, model, save_mode='last', **kwargs):
         """
@@ -26,11 +28,12 @@ class Checkpoint():
         if not os.path.exists(self.path):
             os.makedirs(self.path)
 
-        model_path = "_".join([model.model_name,save_mode])
-        
+        model_path = "_".join([model.model_name, save_mode])
+
         epoch = int(kwargs['epoch']) if 'epoch' in kwargs else 0
         iters = int(kwargs['iters']) if 'iters' in kwargs else 0
-        best_value = float(kwargs['best_value']) if 'best_value' in kwargs else 0
+        best_value = float(kwargs['best_value']
+                           ) if 'best_value' in kwargs else 0
         class_names = kwargs['class_names'] if 'class_names' in kwargs else None
         config = kwargs['config'] if 'config' in kwargs else None
         config_dict = config.to_dict()
@@ -47,8 +50,9 @@ class Checkpoint():
         if model.scaler is not None:
             weights[model.scaler.state_dict_key] = model.scaler.state_dict()
 
-        torch.save(weights, os.path.join(self.path,model_path)+".pth")
-    
+        torch.save(weights, os.path.join(self.path, model_path)+".pth")
+
+
 def load_checkpoint(model, path):
     """
     Load trained model checkpoint
@@ -65,9 +69,9 @@ def load_checkpoint(model, path):
 
     try:
         model.model.load_state_dict(state["model"])
-        if model.optimizer is not None:
+        if model.optimizer is not None and 'optimizer' in state.keys():
             model.optimizer.load_state_dict(state["optimizer"])
-        if model.scaler is not None:
+        if model.scaler is not None and 'amp_scaler' in state.keys():
             model.scaler.load_state_dict(state[model.scaler.state_dict_key])
     except RuntimeError as e:
         try:
@@ -82,19 +86,24 @@ def load_checkpoint(model, path):
         print(f'Set learning rate to {current_lr}')
     print("Loaded Successfully!")
 
+
 def get_epoch_iters(path):
     state = torch.load(path)
     epoch_idx = int(state['epoch']) if 'epoch' in state.keys() else 0
     iter_idx = int(state['iters']) if 'iters' in state.keys() else 0
-    best_value = float(state['best_value']) if 'best_value' in state.keys() else 0.0
+    best_value = float(state['best_value']
+                       ) if 'best_value' in state.keys() else 0.0
 
     return epoch_idx, iter_idx, best_value
 
+
 def get_class_names(path):
     state = torch.load(path)
-    class_names = state['class_names'] if 'class_names' in state.keys() else None
+    class_names = state['class_names'] if 'class_names' in state.keys(
+    ) else None
     num_classes = len(class_names) if class_names is not None else 1
     return class_names, num_classes
+
 
 def get_config(path, ignore_keys=[]):
     state = torch.load(path)


### PR DESCRIPTION
When there are no ```optimizer``` and ```scaler``` in the ```state_dict's keys```, an error occurs. I've experienced it when tried to load a yolov5 model. So i've added two more conditions below (tested):

![image](https://user-images.githubusercontent.com/47696901/144607885-4174a6d5-918e-49ef-86b2-2c390892b90a.png)
